### PR TITLE
Add Federated Orchestrator to the BB menu

### DIFF
--- a/docs/technical/federated-orchestrator-bb.md
+++ b/docs/technical/federated-orchestrator-bb.md
@@ -1,0 +1,3 @@
+# Federated Orchestrator
+
+See the [documentation for the `openEO Aggregator`](https://open-eo.github.io/openeo-aggregator/){:target="_blank"} which provides full details - including design, installation and usage information.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - Building Blocks:
         - MLOps: technical/mlops-bb.md
         - Resource Registration: technical/resource-registration-bb.md
+        - Federated Orchestrator: technical/federated-orchestrator-bb.md
         - Example (template): technical/BB-example.md
 
 theme:


### PR DESCRIPTION
Adds link to "openeo Aggregator" docs under "Technical BB" menu


Unlike the existing other menu items, this one creates an "external" link to the documentation embedded in the "openEO Aggregator" project, as discussed at https://github.com/EOEPCA/roadmap/issues/7#issuecomment-2114750204:
> is it a possibility to link to repo's under: https://github.com/Open-EO/, perhaps using a git submodule?
I would like to keep the docs close to the actual components, so that would be the best place. Of course I can create a repo under eoepca, but then I see a risk in terms of discoverability and long term maintenance.


refs: https://github.com/Open-EO/openeo-aggregator/issues/142, https://github.com/EOEPCA/roadmap/issues/7, https://github.com/EOEPCA/roadmap/issues/11